### PR TITLE
Add Python ReAct autonomous agent with tests

### DIFF
--- a/autonomous_agent/__init__.py
+++ b/autonomous_agent/__init__.py
@@ -1,0 +1,12 @@
+"""Package for autonomous agent."""
+
+from .agent import ReActAgent
+from .actions import read_file, write_file, run_command, git_commit
+
+__all__ = [
+    "ReActAgent",
+    "read_file",
+    "write_file",
+    "run_command",
+    "git_commit",
+]

--- a/autonomous_agent/actions.py
+++ b/autonomous_agent/actions.py
@@ -1,0 +1,33 @@
+"""Basic actions for the autonomous agent."""
+
+import subprocess
+from pathlib import Path
+from typing import Optional
+
+
+def read_file(path: str) -> str:
+    """Read and return the contents of a file."""
+    return Path(path).read_text()
+
+
+def write_file(path: str, content: str) -> None:
+    """Write content to a file."""
+    Path(path).write_text(content)
+
+
+def run_command(command: str, timeout: Optional[int] = None) -> str:
+    """Run a shell command and return its output."""
+    result = subprocess.run(
+        command,
+        shell=True,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+    return result.stdout + result.stderr
+
+
+def git_commit(message: str) -> None:
+    """Commit all changes with the given message."""
+    subprocess.run(["git", "add", "-A"], check=True)
+    subprocess.run(["git", "commit", "-m", message], check=True)

--- a/autonomous_agent/agent.py
+++ b/autonomous_agent/agent.py
@@ -1,0 +1,105 @@
+"""Implementation of a simple ReAct autonomous agent."""
+
+import json
+import os
+import time
+from dataclasses import dataclass, field
+from typing import Any, Dict, List
+
+import openai
+from dotenv import load_dotenv
+
+from .actions import git_commit, read_file, run_command, write_file
+
+load_dotenv()
+
+
+@dataclass
+class StepResult:
+    reasoning: str
+    action: Dict[str, Any]
+    observation: str
+
+
+@dataclass
+class ReActAgent:
+    goal: str
+    max_steps: int = 10
+    timeout: int = 300
+    model: str = "o3/codex-1"
+    history: List[Dict[str, str]] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        openai.api_key = os.getenv("OPENAI_API_KEY")
+        self.start_time = time.time()
+        self.history.append({"role": "system", "content": f"You are an autonomous agent with the goal: {self.goal}"})
+
+    def call_model(self, prompt: str) -> str:
+        """Call the OpenAI API with the given prompt."""
+        response = openai.ChatCompletion.create(
+            model=self.model,
+            messages=self.history + [{"role": "user", "content": prompt}],
+        )
+        return response.choices[0].message["content"].strip()
+
+    def parse_action(self, text: str) -> Dict[str, Any]:
+        """Parse the assistant response into an action."""
+        try:
+            return json.loads(text)
+        except json.JSONDecodeError:
+            return {"name": "noop", "args": {"response": text}}
+
+    def execute_action(self, action: Dict[str, Any]) -> str:
+        name = action.get("name")
+        args = action.get("args", {})
+        if name == "read_file":
+            return read_file(**args)
+        if name == "write_file":
+            write_file(**args)
+            return "file written"
+        if name == "run_command":
+            return run_command(**args)
+        if name == "git_commit":
+            git_commit(**args)
+            return "committed"
+        if name == "finish":
+            return "goal achieved"
+        return f"unknown action: {name}"
+
+    def step(self, step_id: int) -> StepResult:
+        prompt = "Think step"  # placeholder
+        assistant_reply = self.call_model(prompt)
+        action = self.parse_action(assistant_reply)
+        observation = self.execute_action(action)
+        self.history.append({"role": "assistant", "content": assistant_reply})
+        self.history.append({"role": "system", "content": f"Observation: {observation}"})
+        git_commit(f"Agent step {step_id}")
+        return StepResult(reasoning=assistant_reply, action=action, observation=observation)
+
+    def run(self) -> None:
+        for step_id in range(1, self.max_steps + 1):
+            if time.time() - self.start_time > self.timeout:
+                print("Timeout reached, exiting")
+                break
+            result = self.step(step_id)
+            print(f"Step {step_id} reasoning: {result.reasoning}")
+            print(f"Step {step_id} action: {result.action}")
+            print(f"Step {step_id} observation: {result.observation}")
+            if result.action.get("name") == "finish":
+                print("Goal achieved")
+                break
+
+
+def main() -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Run an autonomous agent")
+    parser.add_argument("goal", help="Goal for the agent to accomplish")
+    args = parser.parse_args()
+
+    agent = ReActAgent(goal=args.goal)
+    agent.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/autonomous_agent/main.py
+++ b/autonomous_agent/main.py
@@ -1,0 +1,6 @@
+"""Entry point for running the autonomous agent."""
+
+from .agent import main
+
+if __name__ == "__main__":
+    main()

--- a/autonomous_agent/requirements.txt
+++ b/autonomous_agent/requirements.txt
@@ -1,0 +1,2 @@
+openai>=1.0
+python-dotenv

--- a/autonomous_agent/tests/test_actions.py
+++ b/autonomous_agent/tests/test_actions.py
@@ -1,0 +1,24 @@
+import os
+from unittest import mock
+
+import pytest
+
+from autonomous_agent import actions
+
+
+def test_read_write_file(tmp_path):
+    file_path = tmp_path / "test.txt"
+    actions.write_file(str(file_path), "hello")
+    assert actions.read_file(str(file_path)) == "hello"
+
+
+def test_run_command():
+    output = actions.run_command("echo hi")
+    assert "hi" in output
+
+
+def test_git_commit():
+    with mock.patch("subprocess.run") as run_mock:
+        actions.git_commit("msg")
+        run_mock.assert_any_call(["git", "add", "-A"], check=True)
+        run_mock.assert_any_call(["git", "commit", "-m", "msg"], check=True)

--- a/autonomous_agent/tests/test_agent.py
+++ b/autonomous_agent/tests/test_agent.py
@@ -1,0 +1,18 @@
+from unittest import mock
+
+import pytest
+
+from autonomous_agent.agent import ReActAgent
+
+
+@mock.patch("autonomous_agent.agent.git_commit")
+@mock.patch("autonomous_agent.agent.run_command", return_value="ok")
+@mock.patch("autonomous_agent.agent.write_file")
+@mock.patch("autonomous_agent.agent.read_file", return_value="content")
+@mock.patch("autonomous_agent.agent.openai.ChatCompletion.create")
+def test_agent_step(mock_create, mock_read, mock_write, mock_run, mock_commit):
+    mock_create.return_value = mock.Mock(choices=[mock.Mock(message={"content": '{"name": "finish"}'})])
+    agent = ReActAgent(goal="test", max_steps=1)
+    agent.step(1)
+    assert mock_create.called
+    assert mock_commit.called


### PR DESCRIPTION
## Summary
- add `autonomous_agent` package containing a simple ReAct-style agent
- support file and shell actions and automatic git commits
- expose CLI entry point
- provide pytest coverage for agent logic and actions

## Testing
- `pip install openai python-dotenv`
- `pytest -q autonomous_agent/tests`

------
https://chatgpt.com/codex/tasks/task_e_6857484cb96c83228054da6dded4a816